### PR TITLE
Add instructor notes and update docs

### DIFF
--- a/.live-demo-content/README.md
+++ b/.live-demo-content/README.md
@@ -1,4 +1,7 @@
-This directory has two sets of contents:
+This directory contains files for instructors to support live demonstrations.
 
-- The `issue-templates/` directory holds markdown files representing issues that need to be filed for use during live demos by (pending) GHA
-- Notebook [`analyses/explore-spotify-variation-with-UMAPs.Rmd`](analyses/explore-spotify-variation-with-UMAPs.Rmd), which has expanded the [`explore-spotify-variation.Rmd`](../analyses/explore-spotify-variation.Rmd) notebook with UMAPs for use during the live demo of performing code review
+* The notebook [`analyses/explore-spotify-variation-with-UMAPs.Rmd`](analyses/explore-spotify-variation-with-UMAPs.Rmd), which has expanded the [`explore-spotify-variation.Rmd`](../analyses/explore-spotify-variation.Rmd) notebook with UMAPs for use during the live demo of performing code review.
+  * The file [`spotify-pr-text.md`](spotify-pr-text.md) contains the text that can be used as the pull request comment when filing a PR with with above notebook.
+* The [`instructor-notes`](./instructor-notes) directory holds notes for instructors detailing steps to present during each live demonstration.
+* The [`issue-templates`](./issue-templates) directory holds markdown files representing issues that need to be filed for use during live demos by [this github action](../.github/workflows/file-live-demo-issues.yml).
+* The [`scripts`](./scripts) directory contains completed "solution" scripts that are written during live demonstration, as documented in [`scripts/README.md`](./scripts/README.md).

--- a/.live-demo-content/README.md
+++ b/.live-demo-content/README.md
@@ -4,4 +4,4 @@ This directory contains files for instructors to support live demonstrations.
   * The file [`spotify-pr-text.md`](spotify-pr-text.md) contains the text that can be used as the pull request comment when filing a PR with with above notebook.
 * The [`instructor-notes`](./instructor-notes) directory holds notes for instructors detailing steps to present during each live demonstration.
 * The [`issue-templates`](./issue-templates) directory holds markdown files representing issues that need to be filed for use during live demos by [this github action](../.github/workflows/file-live-demo-issues.yml).
-* The [`scripts`](./scripts) directory contains completed "solution" scripts that are written during live demonstration, as documented in [`scripts/README.md`](./scripts/README.md).
+* The [`scripts`](./scripts) directory contains completed "solution" scripts that are written during live demonstrations, as documented in [`scripts/README.md`](./scripts/README.md).

--- a/.live-demo-content/README.md
+++ b/.live-demo-content/README.md
@@ -1,4 +1,4 @@
 This directory has two sets of contents:
 
 - The `issue-templates/` directory holds markdown files representing issues that need to be filed for use during live demos by (pending) GHA
-- Notebook [`explore-spotify-variation-with-UMAPs.Rmd`](explore-spotify-variation-with-UMAPs.Rmd), which has expanded the [`explore-spotify-variation.Rmd`](../analyses/explore-spotify-variation.Rmd) notebook with UMAPs for use during the live demo of performing code review
+- Notebook [`analyses/explore-spotify-variation-with-UMAPs.Rmd`](analyses/explore-spotify-variation-with-UMAPs.Rmd), which has expanded the [`explore-spotify-variation.Rmd`](../analyses/explore-spotify-variation.Rmd) notebook with UMAPs for use during the live demo of performing code review

--- a/.live-demo-content/instructor-notes/README.md
+++ b/.live-demo-content/instructor-notes/README.md
@@ -1,0 +1,2 @@
+This directory contains instructor notes for live demonstrations during the workshop.
+Each markdown file contextualizes a given live demonstration and walks through the steps planned for live demonstration itself.

--- a/.live-demo-content/instructor-notes/git-basics.md
+++ b/.live-demo-content/instructor-notes/git-basics.md
@@ -1,0 +1,31 @@
+# `git` basics live demonstration
+
+
+## Before demonstration
+
+Before the live demo, slides and/or some browser navigation will have introduced the following concepts and/or commands:
+
+- `add/commit/push` (including `commit` flavors) `status`, `diff`
+- `.gitignore` and `.gitkeep` files
+- _Briefly_, the concept of feature branches
+- Undoing or modifying changes
+  - `checkout`/`restore (--staged)`, `reset`, `revert`, `commit --amend`
+
+## Live demonstration
+
+- In browser, navigate to https://github.com/AlexsLemonade/2023-chop-training-demo/issues to see an issue that we are going to demonstrate tackling
+- Locally, use terminal to navigate to repo and create a feature branch: `git switch -c <your user name>/<issue #>-histogram-bins>`
+- In the directory, create and open an RStudio project, which will have the effect of creating a `.gitignore` file with some pre-populated contents, and it will allow us to use `{here}` throughout.
+Look around the repository to show trainees what we are working with in general; "accidentally modify" an existing file while doing this.
+- There will now be a few `add/commit` (using `git commit -m`) cycles in this order, using `git status` liberally, and using `git diff` on each file before it is added
+  1. Run a `git status` before beginning to code.
+  Discuss the `.gitignore` changes, and `git restore` accidentally modified file. Add/commit `.gitignore`.
+  2. Add `ggsave()` to the script. Add/commit.
+  3. Add `optparse` with the bins options to the script, and modify export file name. Add/commit.
+  4. Run script so a plot is included now in `plots/`. `git rm` the `plots/.gitkeep`. Add/commit.
+- Finally, `push` which will fail since there is no remote branch; `git` gives us the command for success
+- In browser, see the pushed code and demonstrate opening a PR to `main`. PR should include the following components:
+  - Before writing any text, see how you can view the file changes and then make any code updates _before_ filing the PR (with any luck GitHub will demand a newline somewhere)
+  - `Closes #<issue>`
+  - Text explaining changes made
+  - Specific things reviewer might check for

--- a/.live-demo-content/instructor-notes/merge-conflict.md
+++ b/.live-demo-content/instructor-notes/merge-conflict.md
@@ -1,0 +1,124 @@
+# Dealing with merge conflicts live demonstration
+
+## Dependencies
+
+This live demo will make use of two frameworks for resolving merge conflicts:
+- [GitKraken](https://www.gitkraken.com/)
+- [Visual Studio Code](https://code.visualstudio.com/)
+
+The instructor leading the live demo will need to have these softwares installed, and further ensure that the demo repository is already in `GitKraken`.
+
+## Before demonstration
+
+This live demo will build on two pieces of code:
+
+- The script `scripts/plot_penguins_histogram.R` written as part of the [`git` basics](./git-basics.md) live demo, which plots and exports a barebones histogram of `palmerpenguins::penguins` bill depth.
+- The script `scripts/penguins_calculate_mass.R` written as part of the [working with branches](./working-with-branches.md) live demo, which calculates mean `palmerpenguins::penguins` mass across species.
+
+Before beginning this live demo, navigate to GitHub and show the script to re-orient trainees to the relevant code.
+
+In addition, slides will have introduced the concept of merge conflicts, when they might arise, and how to avoid them in the first place to the extent possible.
+Slides should also introduce a schematic of the live demo: We're going to have several branches off of the same base, each one modifying the same lines of code such that changes cannot be automatically merged.
+Further explain that in a real-life scenario, something like this might occur when three team members are each working in one of these branches, simultaneously modifying the same code.
+
+
+## Live demonstration
+
+
+* Ensure we are up-to-date in the `main` branch, and create (`git branch <branch name>`) three branches (emphasizing that these "quick and dirty" branch names are for the purposes of demonstrating merge conflicts only, and otherwise are not very good!):
+  * `code-mod-1`
+  * `code-mod-2`
+  * `code-mod-3`
+
+### Setup to induce merge conflicts
+
+First we'll need to modify lines in each of the two relevant scripts, which will allow the `code-mod-2` and `code-mod-3` to have conflicts with `main`.
+
+
+* Enter into the first branch `git switch code-mod-1`
+
+* First, modify `scripts/penguins-calculate-mass.R` as follows, and `add/commit` the change.
+```r
+# original code
+group_by(species)
+
+# new code
+group_by(species, island)
+```
+* Second, modify `scripts/plot_penguins_histogram.R` as follows (ensure code changes are on the same line to induce later conflicts), and `add/commit` the change.
+```r
+# original code
+geom_histogram(bins = n_bins)
+
+# new code
+geom_histogram(bins = n_bins, color = "dodgerblue", fill = "gold")
+```
+* Push, and file a quick 'n dirty PR, which co-instructor quickly approves, and merge the PR.
+  * Note aloud that we are moving through this step quickly only for the purpose of the demonstration!
+
+### Merge conflict 1: Resolve with VS Code
+
+This merge conflict will focus on changes to `scripts/penguins_calculate_mass.R`.
+
+* Locally, checkout the `main` branch and sync up (`git switch main; git pull`)
+* Checkout the second branch: `git switch hist-mod-2`
+  * Note that if we were to run `git merge main` _now_, we would avoid a merge conflict by keeping our `base` up to date before making changes in this new branch.
+  We're not going to do that for the purposes of demonstration, but it's good to know.
+* Modify the script to induce a conflict, run the script to produce an updated TSV, and `add/commit/push` all changes.
+```r
+# original code
+group_by(species)
+
+# new code
+filter(year == 2008) |>
+group_by(species, island)
+```
+* File quick 'n dirty PR to `main`, and the PR will tell us that we have merge conflict.
+* Return to local repository (not in browser), and run `git merge main` to "get" the conflict locally
+* Open VS Code to resolve the conflict
+  * Open the _script_ in VS Code and explain the merge conflict view
+  * Explain that "theirs" = "Incoming change" and "ours" = "Current change"
+  * Click the handy "Accept Current Change" text
+* Open the TSV file in VS Code and look at the conflict
+  * Explain that we could, for this simple example, choose "ours"/"theirs", but it's easy to get confused since it is not immediately obvious from the data itself which is which (same columns & types).
+  * This confusion would be even greater for larger/more realistic data files.
+* Re-run the script whose conflict has been resolved to resolve the TSV conflict.
+A bonus benefit of this step is extra confirmation that you have indeed resolved the conflict; if `>>>>` etc. remains in your file, the code will not run.
+* Return to command line, run `git status`, `commit` the resolved conflict, and `push`.
+* In browser, refresh the PR and see that there is no longer a merge conflict message.
+  * In the interest of time, this PR does not need to be approved/merged.
+
+
+### Merge conflict 2: Resolve with GitKraken
+
+This merge conflict will focus on changes to `scripts/plot_penguins_histogram.R`.
+
+* Checkout the third branch: `git switch code-mod-3`
+  * Remind everyone via `git log` that its base remains `main` _before_ `code-mod-1` was merged in
+* Modify the script to induce a conflict, run it to produce an updated PNG, and `add/commit` all changes (`push` is less critical for this demo; doesn't matter if that is skipped)
+```r
+# original code
+geom_histogram(bins = n_bins)
+
+# new code
+geom_histogram(bins = n_bins, color = "deepskyblue1", fill = "olivedrab3")
+```
+* Run `git merge main` via command line, which will inform us we have a merge conflict.
+This approach shows a different way that one can discover a merge conflict, v.s. the last example when it was discovered by filing a PR.
+* Note that we cannot directly compare "ours"/"theirs" in a PNG by just opening the file, but GitKraken can help
+* Resolve the R script conflict in GitKraken.
+  * Open the repository in GitKraken and show the conflict view
+  * Explain that "theirs" is on the top left, and "ours" is on the top right
+  * Fix the conflict by ensuring only "ours" is in the output frame below
+* Resolve the PNG conflict.
+GitKraken will allow us to choose which PNG, but we might prefer to re-run the script anyways to be sure the PNG is correct.
+* Commit within GitKraken directly to conclude the merge
+
+### Final punchlines of demo
+
+* Sync up with your base branch sooner rather than later
+* Don't let branches/PRs get too stale, as they will get increasingly out of sync
+* Coordinate with your team to reduce odds of working on the same lines of code at once
+
+
+

--- a/.live-demo-content/instructor-notes/pr-review.md
+++ b/.live-demo-content/instructor-notes/pr-review.md
@@ -1,0 +1,30 @@
+# `git` basics live demonstration
+
+
+## Before demonstration
+
+Before the live demo, the co-instructor (i.e., instructor who is _not_ leading the demo) will have opened a pull request that modifies and re-renders an existing notebook [`explore-spotify-variation.Rmd`](https://github.com/AlexsLemonade/2023-chop-training-demo/blob/5ea683d571d89ceb19572359dd9c633f6f247987/scripts/explore-spotify-variation.Rmd).
+
+
+## Live demonstration
+
+* Navigate to the open pull request and discuss review at a high level:
+  * Read through the PR, which links the issue, and discuss how a well-crafted PR can support review
+  * Show the Files Changed tab, different views of diffs, and hiding files you have already reviewed to reduce clutter
+  * Show views of individual commits, and note that commit messages are helpful for review
+* Begin reviewing within GitHub, leaving the following _in-line_ comments for review:
+  * In-line comment (not a suggestion)
+    * Need to add a `sessionInfo()` chunk
+  * In-line suggestions
+    * Need to set a seed
+    * Need to set appropriate `ggplot` theme for the UMAP (no axis ticks, labels)
+  * File-level comment
+    * Need to include more markdown text contextualizing code chunks.
+    This could additionally be included in the overall review comment as a major point to address.
+* Check out branch locally to run the code, during which package management problems are caught:
+  * `{umap}` was not loaded into environment
+  * `{patchwork}` was used, but the reviewer does not have the package installed
+* Leave overall review starting with some form of "Thanks for doing this!"
+  * Overall review should include comment that `{umap}` package needs to be in the environment, either via `library()` or using `::`
+  * Also suggest that author should open up a separate issue to use `{renv}` in the project to ensure environment consistency given that reviewer did not have `{patchwork}` dependency
+* Publish review as "Comment," but discuss consequences if "Request changes" were used instead.

--- a/.live-demo-content/instructor-notes/stacking.md
+++ b/.live-demo-content/instructor-notes/stacking.md
@@ -1,0 +1,63 @@
+# Stacking branches live demonstration
+
+## Before demonstration
+
+Before the live demo, slides will have covered only the concept of `git` branch stacking, as well as why it's a challenging thing to do in forks.
+There are no new `git` commands that need to be introduced for this live demo.
+
+Note that the second section of the demo should be conducted from a _fork_ of the demo repository.
+Depending on the given workshop audience, this fork can be set up in advance of the workshop, or you can show creating and cloning the fork during the workshop, which includes setting the upstream repository: `git remote add upstream git@github.com:<upstream account>/<upstream repo>`.
+## Live demonstration
+
+### Part 1: How to stack branches
+
+> This first part of the demonstration is based around one issue with two related tasks:
+>   * Task 1: Write a `utils.R` script with a function that, given a data frame and two numeric variables, builds a regression model and returns the `broom::tidy()` output
+>   * Task 2: Write a script called `model-penguins.R` that sources `utils.R`, builds a model from penguin variables, and exports results to a TSV
+
+* First, run `git pull` in `main` to ensure I am synced up before I start new work
+* Create and switch to first branch: `git switch -c <username>/<issue #>-utils-linear-model`
+* Perform one `add/commit/push` (with `status` and `diff`) to create the `utils.R` script
+  * For this first commit, _do not_ include documentation of this function
+* Open PR GitHub, but don't spend much time crafting a perfect PR as that is not the point of this demo
+  * In the background, co-instructor will leave a review that the code needs docs
+* While still in `<username>/<issue #>-utils-linear-model`, create and switch to branch `<username>/<issue #>-build-penguin-model`
+* Perform one `add/commit/push` (with `status` and `diff`) to create the `model-penguins.R` script
+* File a PR in GitHub, setting the base branch to `<username>/<issue #>-utils-linear-model`
+  * Demonstrate how the overall file diff is different depending on the base
+* Return to original PR where I see a review comment
+* Back on command line, return to `<username>/<issue #>-utils-linear-model`, implement requested changes, and `add/commit/push`.
+* PR is now accepted and merged, and we _delete_ the remote branch `<username>/<issue #>-utils-linear-model`
+* Return to other open PR with the script that performs penguin modeling
+  * Note that the base has changed to `main` now that the remote branch was deleted
+  * Also note that the branch is no longer up-to-date with `main`.
+  Explain two ways to handle this (but ultimately do the first one):
+    * Within GitHub, merge `main` into `<username>/<issue #>-build-penguin-model`
+    * Locally, you can checkout `main`, pull down, checkout `<username>/<issue #>-build-penguin-model`, merge on command line, and then push.
+* The second PR can now be approved and merged into `main`.
+Ensure this is completed, since this code is required for part 2 of this demo.
+
+
+### Part 2: How to approximate stacking when you are working in a fork
+
+> The second part of the demonstration is based around a different issue with two related tasks:
+>   * Task 1: Add a function to the `utils.R` script that, given a data frame and two numeric variables, exports a scatterplot
+>   * Task 2: Modify the script `model-penguins.R` to make and export a scatterplot of variables used in the regression
+
+* Explain again that stacking won't work well, _unless_ you want to have a review performed in your fork.
+  * If you want the full project history including reviews to be present in the `upstream` repository, this will not meet your needs
+* Brief detour back to slides to show a schematic of what we are going to do in this demo & relationship among branches
+* Navigate via command line to the _fork_ of the repo, and ensure the `main` branch is up-to-date with `upstream/main`
+* Create and enter branch off of `main`: `<username>/<issue #>-full-work`
+* Perform three `add/commit` cycles (can `push` as well):
+  * First, add the plotting function to the `utils.R` script
+  * Second, use the function in the `model-penguins.R` script
+  * Third, run the script to export PNG to `plots/`
+* View the `git log`, and identify which commits should be "stacked" on which: The latter two commits should be "stacked" on the first commit.
+This means we need to divvy up this code up into two separate branches.
+  * Emphasize that these small, focused commits allow us to cherry pick individual tasks for each issue, i.e., issue tasks are not muddled together in the same commit.
+* Return to `main` and create/enter first branch for cherry picking: `git switch -c <username>/<issue #>-scatterplot-function`
+* `git cherry-pick` the first commit into this branch
+* Return to `main` and create/enter second branch (`git switch -c <username>/<issue #>-penguins-scatterplot`), and cherry-pick the second two commits
+* Now we have two branches which are _sort of_ stacked (show with `git branch -a`), at least in the scope of their work, and a third which encompasses all work for posterity, which we don't delete just in case
+* The two issue-specific branches can be filed to the `upstream` repo's `main` branch, with sufficient context in each PR to help reviewers understand how the PRs are related

--- a/.live-demo-content/instructor-notes/working-with-branches.md
+++ b/.live-demo-content/instructor-notes/working-with-branches.md
@@ -1,0 +1,75 @@
+# Working with multiple branches live demonstration
+
+## Before demonstration
+
+Before the live demo, slides will introduce the follow concepts/commands:
+
+* Exploring project history in GitHub using `scpca-nf`
+  * See past commits, releases and/or tags
+  * `Blame` view (use [`scpca-nf/bin/post_process_sce.R`](https://github.com/AlexsLemonade/scpca-nf/blob/main/bin/post_process_sce.R), a script with three contributors)
+* Introduce feature branches conceptually and why we use them, including informative branch names
+  * Note that more discussion of feature branches will come later in the afternoon during git workflow slides
+* Introduce `git merge` and (why not to use) `git rebase`
+* Introduce `git checkout` (as in `git switch`) and `git branch`
+* Introduce `git stash` and `git cherry-pick`
+* Introduce concept of stacking, which we will come back to in day 2
+Note that stacking will not be part of this live demo.
+* Show a brief schematic of what we will do in the live demo to help orient trainees
+  * We will have four branches working on complementary, _but different_ (no merge conflicts, please!), areas of the code base
+  * Show issues that each branch is going to tackle
+   * Branch 1 (`<username>/<issue #>-2008-penguins`): Add script to export TSV of penguins sampled in 2008 to `results/`
+   * Branch 2 (`<username>/<issue #>-adelie-penguins`): Add script to export TSV of only Adelie penguins to `results/`
+   * Branch 3 (`<username>/<issue #>-penguins-species-count`): Add script to export TSV of number of each species of penguin to `results/`
+     * This branch will have already been created before the workshop, to save time
+   * Branch 4 (`git branch <username>/<issue #>-penguins-species-mass`): Add script to export TSV of the mean mass of each penguins species to `results/`
+     * This branch will have already been created before the workshop, to save time
+  * Explain demostration scenarios:
+    * First, successfully working with two branches, and note that success is achieved in part by lots of `git status`
+    * Second, two common "gotchas" when working with multiple branches
+
+## Live demonstration
+
+### Scenario 1: Working successfully between two branches: 2008 and Adelie penguins
+
+* Run `git switch -c <username>/<issue #>-2008-penguins` to create, switch to new branch
+* Three `add/commit/push` cycles with `git status` along the way:
+  * Add script to perform calculation
+  * Run the script to produce output TSV file
+  * Now can remove `results/.gitkeep`
+* Now, `git switch main`, and create and enter Branch 2 (`git switch -c <username>/<issue #>-adelie-penguins`).
+  * This demonstrates branching off the correct base
+* Two `add/commit/push` cycles with `git status` along the way (add script, add TSV)
+
+### Scenario 2: Uncommitted work in the wrong branch: Penguin species counts
+
+* Do _not_ return to `main`, but stay in the (wrong) `<username>/<issue #>-adelie-penguins` branch
+* Write script for the next task (penguin species counts)
+* Run `git status` in anticipation of `add/commit`, and realize we're in the wrong branch.
+This further demonstrates the benefit of running `git status` frequently.
+* Use `git stash` to stash the work
+* Enter branch 3: `git switch <username>/<issue #>-penguins-species-count`
+* Use `git stash apply` to apply the first item in stash
+  * Mention that `git stash pop` would have wholesale removed it from the stash but `apply` retains it
+* Add/commit the script.
+* In the interest of time, can either run the script and add/commit the TSV file, or move on.
+
+
+### Scenario 3: Committed work in the wrong branch: Penguin species mean mass
+> Bonus: Experience the benefits of branch protection rules
+
+* Switch back to `main` branch, but do _not_ switch into the `<username>/<issue #>-penguins-species-mass` branch
+* `add/commit` the script
+* Run the script & `add/commit` the result TSV
+* Run `git push`, which should fail due to branch protections, which causes us to "realize" we have worked in the wrong branch.
+  (But caution: If you are in a fork, you may need to set up your own protections!)
+  Therefore, we need to cherry pick this commit into the proper branch
+ * Identify the commit hashes we'd like to cherry pick out of this branch using `git log` for help
+* Enter branch 4: `git switch <username>/<issue #>-penguins-species-mass`
+* `git cherry-pick <hash>`
+* Behold the updated `git status` in this branch.
+* File a quick PR to `main`
+  * Co-instructor will approve this PR in the background and merge into `main`, allowing this script to be used later in the merge conflict demonstration
+* Switch back to `main` and...
+  * Run `git status` to see the commits remain (cherry pick will duplicate, which we don't always want!), but we'd like to remove them
+  * Run `git reset --hard <last commit to keep>` to remove the commits that we don't want to be in our local `main`.
+  Explain that `--hard` is going to really be _hard_, and may not always be what you want!

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ If you do not provide these inputs, you will have to manually assign the resulti
 
 Two branches will need to be created in advance to support the "Working with branches" live demonstration.
 These branches should be created off of `main` and should be named as follows, where `<username>` is the GitHub handle of who will be performing the demonstration, and `<issue number>` is the number of the relevant issue that is filed from the [issue creation GHA](.github/workflows/file-live-demo-issues.yml).
-* `<username>/<issue number>-penguins-species-count` is the branch used to address the issue [.live-demo-content/issue-templates/03-working-with-branches.md](.live-demo-content/issue-templates/03-working-with-branches.md).
-* `<username>/<issue number>-penguins-species-mass` is the branch used to address the issue [.live-demo-content/issue-templates/04-working-with-branches.md](.live-demo-content/issue-templates/04-working-with-branches.md).
+* `<username>/<issue number>-penguins-species-count` is the branch used to address the issue [`.live-demo-content/issue-templates/03-working-with-branches.md`](.live-demo-content/issue-templates/03-working-with-branches.md).
+* `<username>/<issue number>-penguins-species-mass` is the branch used to address the issue [`.live-demo-content/issue-templates/04-working-with-branches.md`](.live-demo-content/issue-templates/04-working-with-branches.md).
 ### File a PR for live code review
 
 * Whoever is assigned [the issue associated with demonstrating PR review](.live-demo-content/issue-templates/performing-code-review.md) will need to prepare a branch and file a PR, with several commits (whose messages have varying levels of information), that will be reviewed during the live demonstration.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TEMPLATE repository for live demos associated with the Data Lab workshop on code review
-**TEMPLATE repository** for live demos associated with the Childhood Cancer Data Lab workshop on advanced `git`/GitHub and analytical code review.
+**TEMPLATE repository** for live demos associated with the Childhood Cancer Data Lab workshop on advanced `git`/GitHub topics and analytical code review.
 
 Instructor notes for how to lead the live demos are available in [`.live-demo-content/instructor-notes`](.live-demo-content/instructor-notes).
 Reference scripts that are written during live demos are available in [`.live-demo-content/scripts`](.live-demo-content/scripts).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # TEMPLATE repository for live demos associated with the Data Lab workshop on code review
-**TEMPLATE repository** for live demos associated with the Childhood Cancer Data Lab workshop on advanced git topics and analytical code review.
+**TEMPLATE repository** for live demos associated with the Childhood Cancer Data Lab workshop on advanced `git`/GitHub and analytical code review.
 
-Reference scripts for live demos are available in [`.live-demo-content/scripts`](.live-demo-content/scripts).
+Instructor notes for how to lead the live demos are available in [`.live-demo-content/instructor-notes`](.live-demo-content/instructor-notes).
+Reference scripts that are written during live demos are available in [`.live-demo-content/scripts`](.live-demo-content/scripts).
 
 There are several tasks which need to be performed before this workshop begins, as detailed below.
 


### PR DESCRIPTION
Closes https://github.com/AlexsLemonade/training-admin/issues/1015

This PR adds instructor notes to this template repo. For add these, I simply copied over this directory: https://github.com/AlexsLemonade/2023-chop-training/tree/5515577c8e6d018184fd23e7ec079fd3370a34c2/instructor-notes. Thus, most diffs here are just adding those new files.

I also took some time to update the `.live-demo-content/README.md` both to document the instructor notes and add some docs that were needed more generally. Let me know if anything here could/should be expanded!